### PR TITLE
Feat: orientation metadata support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /.vscode/
 .phpunit.result.cache
+.idea

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -31,7 +31,7 @@ class Image
 
     private String $borderColor = '';
 
-    private int $metadataRotation = 0;
+    private int $rotation = 0;
 
     /**
      * @param string $data
@@ -52,15 +52,15 @@ class Image
         if(!empty($orientationType)) {
             switch ($orientationType) {
                 case "3":
-                    $this->metadataRotation = 180;
+                    $this->rotation = 180;
                     break;
 
                 case "6":
-                    $this->metadataRotation = 90;
+                    $this->rotation = 90;
                     break;
 
                 case "8":
-                    $this->metadataRotation = -90;
+                    $this->rotation = -90;
                     break;
             }
         }
@@ -340,8 +340,8 @@ class Image
         }
 
         // Apply original metadata rotation
-        if($this->metadataRotation != 0) {
-            $this->image->rotateImage('transparent', $this->metadataRotation);
+        if($this->rotation != 0) {
+            $this->image->rotateImage('transparent', $this->rotation);
         }
 
         switch ($type) {

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -49,6 +49,9 @@ class Image
 
         // Use metadata to fetch rotation. Will be perform right before exporting
         $orientationType = $this->image->getImageProperties()['exif:Orientation'];
+
+        // Reference: https://docs.imgix.com/apis/rendering/rotation/orient
+        // Mirror rotations are ignored, because we don't support mirroring
         if(!empty($orientationType)) {
             switch ($orientationType) {
                 case "3":


### PR DESCRIPTION
Currently, file preview ignores orientation metadata:

![CleanShot 2022-01-26 at 11 31 47](https://user-images.githubusercontent.com/19310830/151147520-dafe2b2b-deec-4cd8-a94c-4a1fff718587.png)

The image is "officially" rotated incorrectly because that's how the camera stored the file. Cameras do this to prevent having to use the CPU to rotate after taking a photo, so instead, they add `exif:Orientation` metadata.

This PR uses orientation metadata to apply rotation to image at preview stage.

Preview with this PR:

![CleanShot 2022-01-26 at 11 33 57](https://user-images.githubusercontent.com/19310830/151148012-e28421d8-54ae-4c25-9b4e-ef5b232a19fa.png)

Custom user rotation still works as expected, using the metadata rotation as base:

![CleanShot 2022-01-26 at 11 35 15](https://user-images.githubusercontent.com/19310830/151148046-4b180c78-8117-4955-a7a9-1e183fd53c1a.png)

You can learn more about this metadata in [this article](https://www.howtogeek.com/254830/why-your-photos-dont-always-appear-correctly-rotated/).