### PR TITLE
chore: use unique temporary file names to fix race condition

### DIFF
--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -370,11 +370,11 @@ class Image
             case 'avif':
             case 'heic':
                 $signature = $this->image->getImageSignature();
-                $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature.'.'.\strtolower($this->image->getImageFormat()));
+                $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature);
                 if ($temp === false) {
                     throw new Exception('Failed to create temporary file');
                 }
-                $output = tempnam(sys_get_temp_dir(), 'output-'.$signature.'.'.$type);
+                $output = tempnam(sys_get_temp_dir(), 'output-'.$signature);
                 if ($output === false) {
                     if (is_string($temp) && file_exists($temp)) {
                         \unlink($temp);
@@ -389,9 +389,10 @@ class Image
                     // convert temp
                     $quality = (int) $quality;
                     $command = \sprintf(
-                        'magick convert %s -quality %d %s 2>&1', // 2>&1 redirect stderr to stdout
+                        'magick convert %s -quality %d %s:%s 2>&1', // 2>&1 redirect stderr to stdout
                         \escapeshellarg($temp),
                         $quality,
+                        $type,
                         \escapeshellarg($output)
                     );
                     \exec($command, $outputArray, $returnCode);
@@ -436,11 +437,11 @@ class Image
                     }
                 } catch (\Throwable$th) {
                     $signature = $this->image->getImageSignature();
-                    $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature.'.'.\strtolower($this->image->getImageFormat()));
+                    $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature);
                     if ($temp === false) {
                         throw new Exception('Failed to create temporary file');
                     }
-                    $output = tempnam(sys_get_temp_dir(), 'output-'.$signature.'.webp');
+                    $output = tempnam(sys_get_temp_dir(), 'output-'.$signature);
                     if ($output === false) {
                         if (is_string($temp) && file_exists($temp)) {
                             \unlink($temp);

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -371,7 +371,16 @@ class Image
             case 'heic':
                 $signature = $this->image->getImageSignature();
                 $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature.'.'.\strtolower($this->image->getImageFormat()));
+                if ($temp === false) {
+                    throw new Exception('Failed to create temporary file');
+                }
                 $output = tempnam(sys_get_temp_dir(), 'output-'.$signature.'.'.$type);
+                if ($output === false) {
+                    if (is_string($temp) && file_exists($temp)) {
+                        \unlink($temp);
+                    }
+                    throw new Exception('Failed to create output file');
+                }
 
                 try {
                     // save temp
@@ -402,10 +411,10 @@ class Image
 
                     return $data;
                 } finally {
-                    if (file_exists($temp)) {
+                    if (is_string($temp) && file_exists($temp)) {
                         \unlink($temp);
                     }
-                    if (file_exists($output)) {
+                    if (is_string($output) && file_exists($output)) {
                         \unlink($output);
                     }
 
@@ -428,7 +437,16 @@ class Image
                 } catch (\Throwable$th) {
                     $signature = $this->image->getImageSignature();
                     $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature.'.'.\strtolower($this->image->getImageFormat()));
+                    if ($temp === false) {
+                        throw new Exception('Failed to create temporary file');
+                    }
                     $output = tempnam(sys_get_temp_dir(), 'output-'.$signature.'.webp');
+                    if ($output === false) {
+                        if (is_string($temp) && file_exists($temp)) {
+                            \unlink($temp);
+                        }
+                        throw new Exception('Failed to create output file');
+                    }
 
                     // save temp
                     $this->image->writeImages($temp, true);
@@ -458,10 +476,10 @@ class Image
 
                     return $data;
                 } finally {
-                    if ($temp !== null && file_exists($temp)) {
+                    if (is_string($temp) && file_exists($temp)) {
                         \unlink($temp);
                     }
-                    if ($output !== null && file_exists($output)) {
+                    if (is_string($output) && file_exists($output)) {
                         \unlink($output);
                     }
 

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -370,11 +370,11 @@ class Image
             case 'avif':
             case 'heic':
                 $signature = $this->image->getImageSignature();
-                $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature);
+                $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature).'.'.\strtolower($this->image->getImageFormat());
                 if ($temp === false) {
                     throw new Exception('Failed to create temporary file');
                 }
-                $output = tempnam(sys_get_temp_dir(), 'output-'.$signature);
+                $output = tempnam(sys_get_temp_dir(), 'output-'.$signature).'.'.$type;
                 if ($output === false) {
                     if (is_string($temp) && file_exists($temp)) {
                         \unlink($temp);
@@ -389,10 +389,9 @@ class Image
                     // convert temp
                     $quality = (int) $quality;
                     $command = \sprintf(
-                        'magick convert %s -quality %d %s:%s 2>&1', // 2>&1 redirect stderr to stdout
+                        'magick convert %s -quality %d %s 2>&1', // 2>&1 redirect stderr to stdout
                         \escapeshellarg($temp),
                         $quality,
-                        $type,
                         \escapeshellarg($output)
                     );
                     \exec($command, $outputArray, $returnCode);
@@ -437,11 +436,11 @@ class Image
                     }
                 } catch (\Throwable$th) {
                     $signature = $this->image->getImageSignature();
-                    $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature);
+                    $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature).'.'.\strtolower($this->image->getImageFormat());
                     if ($temp === false) {
                         throw new Exception('Failed to create temporary file');
                     }
-                    $output = tempnam(sys_get_temp_dir(), 'output-'.$signature);
+                    $output = tempnam(sys_get_temp_dir(), 'output-'.$signature).'.'.$type;
                     if ($output === false) {
                         if (is_string($temp) && file_exists($temp)) {
                             \unlink($temp);

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -370,17 +370,21 @@ class Image
             case 'avif':
             case 'heic':
                 $signature = $this->image->getImageSignature();
-                $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature).'.'.\strtolower($this->image->getImageFormat());
+
+                $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature);
                 if ($temp === false) {
                     throw new Exception('Failed to create temporary file');
                 }
-                $output = tempnam(sys_get_temp_dir(), 'output-'.$signature).'.'.$type;
+                $temp .= '.'.\strtolower($this->image->getImageFormat());
+
+                $output = tempnam(sys_get_temp_dir(), 'output-'.$signature);
                 if ($output === false) {
                     if (is_string($temp) && file_exists($temp)) {
                         \unlink($temp);
                     }
                     throw new Exception('Failed to create output file');
                 }
+                $output .= '.'.$type;
 
                 try {
                     // save temp
@@ -436,17 +440,21 @@ class Image
                     }
                 } catch (\Throwable$th) {
                     $signature = $this->image->getImageSignature();
-                    $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature).'.'.\strtolower($this->image->getImageFormat());
+
+                    $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature);
                     if ($temp === false) {
                         throw new Exception('Failed to create temporary file');
                     }
-                    $output = tempnam(sys_get_temp_dir(), 'output-'.$signature).'.'.$type;
+                    $temp .= '.'.\strtolower($this->image->getImageFormat());
+
+                    $output = tempnam(sys_get_temp_dir(), 'output-'.$signature);
                     if ($output === false) {
                         if (is_string($temp) && file_exists($temp)) {
                             \unlink($temp);
                         }
                         throw new Exception('Failed to create output file');
                     }
+                    $output .= '.'.$type;
 
                     // save temp
                     $this->image->writeImages($temp, true);

--- a/src/Image/Image.php
+++ b/src/Image/Image.php
@@ -370,8 +370,8 @@ class Image
             case 'avif':
             case 'heic':
                 $signature = $this->image->getImageSignature();
-                $temp = '/tmp/temp-'.$signature.'.'.\strtolower($this->image->getImageFormat());
-                $output = '/tmp/output-'.$signature.'.'.$type;
+                $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature.'.'.\strtolower($this->image->getImageFormat()));
+                $output = tempnam(sys_get_temp_dir(), 'output-'.$signature.'.'.$type);
 
                 try {
                     // save temp
@@ -427,8 +427,8 @@ class Image
                     }
                 } catch (\Throwable$th) {
                     $signature = $this->image->getImageSignature();
-                    $temp = '/tmp/temp-'.$signature.'.'.\strtolower($this->image->getImageFormat());
-                    $output = '/tmp/output-'.$signature.'.webp';
+                    $temp = tempnam(sys_get_temp_dir(), 'temp-'.$signature.'.'.\strtolower($this->image->getImageFormat()));
+                    $output = tempnam(sys_get_temp_dir(), 'output-'.$signature.'.webp');
 
                     // save temp
                     $this->image->writeImages($temp, true);


### PR DESCRIPTION
In converting of images using `exec` for avif, heic and webp images we create temporary files. These file names were based on image signatures, so werent unique to each request. This can lead to race condition errors when let's say a file was deleted but request was cached. 

The PR uses `tempnam` to get unique temporary file names. It also uses `sys_get_temp_dir` instead of `/tmp/` to get default php temporary dir.